### PR TITLE
feat: fix generate rss feed

### DIFF
--- a/data.js
+++ b/data.js
@@ -1,0 +1,1 @@
+export const PUBLIC_SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://mariosouto.com";

--- a/src/infra/Head/Head.jsx
+++ b/src/infra/Head/Head.jsx
@@ -1,3 +1,4 @@
+import { PUBLIC_SITE_URL } from "data";
 import NextHead from "next/head";
 import { withRouter } from "next/router";
 
@@ -13,8 +14,8 @@ export function buildOgImageUrl({
   const parsedParams = btoa(parsedTitle + "%%%%" + parsedRoutePath);
 
 const output = image !== undefined
-  ? `${process.env.NEXT_PUBLIC_SITE_URL}/api/og.png?bg=${parsedImage}`
-  : `${process.env.NEXT_PUBLIC_SITE_URL}/api/og.png?params=${parsedParams}`
+  ? `${PUBLIC_SITE_URL}/api/og.png?bg=${parsedImage}`
+  : `${PUBLIC_SITE_URL}/api/og.png?params=${parsedParams}`
 
 return output;
 }

--- a/src/lib/generateRssFeed.js
+++ b/src/lib/generateRssFeed.js
@@ -8,7 +8,7 @@ import { buildOgImageUrl } from "@src/infra/Head/Head"
 
 export async function generateRssFeed() {
   let articles = await getAllArticles()
-  let siteUrl = process.env.NEXT_PUBLIC_SITE_URL.replace("http://", "https://");
+  let siteUrl = process.env.NEXT_PUBLIC_SITE_URL?.replace("http://", "https://");
   let author = {
     name: config.nickname ? `${config.owner} (${config.nickname})` : config.owner,
     email: config.email,

--- a/src/lib/generateRssFeed.js
+++ b/src/lib/generateRssFeed.js
@@ -5,10 +5,11 @@ import { mkdir, writeFile } from 'fs/promises'
 import { getAllArticles } from './getAllContent'
 import config from "@src/config"
 import { buildOgImageUrl } from "@src/infra/Head/Head"
+import { PUBLIC_SITE_URL } from "data"
 
 export async function generateRssFeed() {
   let articles = await getAllArticles()
-  let siteUrl = process.env.NEXT_PUBLIC_SITE_URL?.replace("http://", "https://");
+  let siteUrl = (PUBLIC_SITE_URL)?.replace("http://", "https://");
   let author = {
     name: config.nickname ? `${config.owner} (${config.nickname})` : config.owner,
     email: config.email,

--- a/src/lib/generateSitemap.js
+++ b/src/lib/generateSitemap.js
@@ -1,11 +1,12 @@
 import fs from "fs";
 import glob from 'fast-glob'
+import { PUBLIC_SITE_URL } from "data";
 
 function addPage(page) {
   const path = page.replace('src/pages', '').replace('.js', '').replace('.mdx', '')
   const route = path === '/index' ? '' : path
   return `  <url>
-    <loc>${`${process.env.NEXT_PUBLIC_SITE_URL}${route}`}</loc>
+    <loc>${`${PUBLIC_SITE_URL}${route}`}</loc>
     <lastmod>${new Date().toISOString()}</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>

--- a/src/pages/_document.jsx
+++ b/src/pages/_document.jsx
@@ -1,3 +1,4 @@
+import { PUBLIC_SITE_URL } from "data"
 import { Head, Html, Main, NextScript } from 'next/document'
 
 const modeScript = `
@@ -43,12 +44,12 @@ export default function Document() {
         <link
           rel="alternate"
           type="application/rss+xml"
-          href={`${process.env.NEXT_PUBLIC_SITE_URL}/rss/feed.xml`}
+          href={`${PUBLIC_SITE_URL}/rss/feed.xml`}
         />
         <link
           rel="alternate"
           type="application/feed+json"
-          href={`${process.env.NEXT_PUBLIC_SITE_URL}/rss/feed.json`}
+          href={`${PUBLIC_SITE_URL}/rss/feed.json`}
         />
       </Head>
       <body className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-900">

--- a/src/pages/api/og.png.jsx
+++ b/src/pages/api/og.png.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 import { ImageResponse } from '@vercel/og'
+import { PUBLIC_SITE_URL } from "data";
 
 const FRAME_PADDING = "6vw";
 
@@ -15,7 +16,7 @@ const boldFontP = fetch(
   new URL("../../../public/fonts/Roboto-Bold.ttf", import.meta.url)
 ).then((res) => res.arrayBuffer());
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL
+const SITE_URL = PUBLIC_SITE_URL;
 
 export default async function handler(req) {
   const [regularFont, boldFont] = await Promise.all([

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -354,10 +354,10 @@ export default function Home({ articles }) {
 }
 
 export async function getStaticProps() {
-  if (process.env.NODE_ENV === 'production') {
+  // if (process.env.NODE_ENV === 'production') {
     await generateSitemap();
     await generateRssFeed();
-  }
+  // }
 
   return {
     props: {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b3b4463</samp>

### Summary
🌐🛠️🖼️

<!--
1.  🌐 - This emoji represents the site URL, which is a global value that affects the whole site and its features. It also suggests the idea of a web or a network, which relates to the site map and the RSS feed.
2.  🛠️ - This emoji represents the refactoring and simplification of the code, which improves its quality and maintainability. It also suggests the idea of tools or utilities, which relates to the functions for generating the site map and the RSS feed.
3.  🖼️ - This emoji represents the Open Graph images, which are visual elements that enhance the site's appearance and shareability on social media platforms. It also suggests the idea of graphics or art, which relates to the API route for generating the images.
-->
This pull request refactors the code to use a constant `PUBLIC_SITE_URL` for the site URL value instead of an environment variable. This improves consistency, readability, and maintainability of the code. It also comments out a conditional check for the environment mode in the home page to test some functions.

> _Oh, we're the coders of the sea, and we like to keep things neat_
> _We use a constant for the site URL, so we don't have to repeat_
> _We comment out the checks for NODE_ENV, to test the sitemap and the feed_
> _And we pull the ropes with all our might, on the count of one, two, three_

### Walkthrough
*  Add `PUBLIC_SITE_URL` constant to `data.js` that exports the site URL from environment variable or default value ([link](https://github.com/devsoutinho/mariosouto.com/pull/7/files?diff=unified&w=0#diff-6f209fec78d74850f3e0e43350d1aa6bfd06f50c601cfb415390ab9dfbd7b761L1-L-1))
* Use `PUBLIC_SITE_URL` instead of `process.env.NEXT_PUBLIC_SITE_URL` in `Head` component to generate Open Graph image URL ([link](https://github.com/devsoutinho/mariosouto.com/pull/7/files?diff=unified&w=0#diff-c624a4f0c9660dbc8100ebf8c812b6d05d0ba1312e0d6de5d15d331ba5980767R1),[link](https://github.com/devsoutinho/mariosouto.com/pull/7/files?diff=unified&w=0#diff-c624a4f0c9660dbc8100ebf8c812b6d05d0ba1312e0d6de5d15d331ba5980767L16-R18))
* Use `PUBLIC_SITE_URL` instead of `process.env.NEXT_PUBLIC_SITE_URL` in `_document` component to add RSS and JSON feeds links ([link](https://github.com/devsoutinho/mariosouto.com/pull/7/files?diff=unified&w=0#diff-306e9b02b4ffe885762820be1134aec46873123d50054d9f654bdf5a7e87b7c2R1),[link](https://github.com/devsoutinho/mariosouto.com/pull/7/files?diff=unified&w=0#diff-306e9b02b4ffe885762820be1134aec46873123d50054d9f654bdf5a7e87b7c2L46-R52))
* Use `PUBLIC_SITE_URL` instead of `process.env.NEXT_PUBLIC_SITE_URL` in `og.png` API route to render HTML template for Open Graph image ([link](https://github.com/devsoutinho/mariosouto.com/pull/7/files?diff=unified&w=0#diff-bd5d1b4939433d1939989210b586adc3e9f97305687060f6b929e4340b748631R3),[link](https://github.com/devsoutinho/mariosouto.com/pull/7/files?diff=unified&w=0#diff-bd5d1b4939433d1939989210b586adc3e9f97305687060f6b929e4340b748631L18-R19))
* Comment out `process.env.NODE_ENV` check in `index` page to run `generateSitemap` and `generateRssFeed` functions in development mode ([link](https://github.com/devsoutinho/mariosouto.com/pull/7/files?diff=unified&w=0#diff-7d335d9933a2a7bd080525968146ecbe3728a087fc5835a439dad04beba2435aL357-R360))

